### PR TITLE
Commit exercise 2

### DIFF
--- a/Constraints/Base.lproj/Main.storyboard
+++ b/Constraints/Base.lproj/Main.storyboard
@@ -1,24 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Constraints" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a9r-7s-ak1">
+                                <rect key="frame" x="103.5" y="246" width="207" height="414"/>
+                                <color key="backgroundColor" systemColor="systemRedColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="a9r-7s-ak1" secondAttribute="height" multiplier="1:2" id="IOM-My-gKS"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="a9r-7s-ak1" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="AbS-g8-TBC"/>
+                            <constraint firstItem="a9r-7s-ak1" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="dph-fN-Oho"/>
+                            <constraint firstItem="a9r-7s-ak1" firstAttribute="width" secondItem="6Tk-OE-BBY" secondAttribute="width" multiplier="0.5" id="qqf-xv-9sZ"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="132" y="91"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
CHALLENGE

Exercise 2

DESCRIPTION

The width of the rectangle must be 50% of the width of the device and the height will be twice its width. It must be tested on various devices and adapted to size. Only the constraints can be used (is not allowed to use code to do this).

EVIDENCE

<img width="1679" alt="Exercise 2 - iPad mini" src="https://user-images.githubusercontent.com/109097550/183990751-2d5d561d-36cb-4334-96a6-3fe42d52b64c.png">

<img width="1679" alt="Exercise 2 - iPhone 8" src="https://user-images.githubusercontent.com/109097550/183991192-c222680e-1551-46d4-bb5d-3b0a591a13ae.png">

<img width="1678" alt="Exercise 2 - iPhone 11 Pro" src="https://user-images.githubusercontent.com/109097550/183991590-aeee0687-8848-495a-a7de-6d27961a989f.png">


